### PR TITLE
use localtunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is the backend service for **m3-chat**, a 100% open-source and free AI chat
 
 The backend exposes an API endpoint that proxies requests to local AI models, streams responses back to the frontend in real-time, and manages communication with the Ollama CLI.
 
-- **Tech stack:** TypeScript, Zod, ElysiaJS, Cloudflare Tunnels
+- **Tech stack:** TypeScript, Zod, ElysiaJS, LocalTunnel
 - **Streaming:** Uses child process streams for live AI responses
 - **Port:** 2000 by default
 - **CORS enabled** for frontend integration

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "bun run --watch app/index.ts",
     "start": "bun run app/index.ts",
-    "tunnel": "cloudflared tunnel --url http://localhost:\"$1\" --config ./cloudflared.tunnel.config.yml"
+    "tunnel": "lt --port 2000 --local-host localhost --print-requests --verbose"
   },
   "dependencies": {
     "@elysiajs/cors": "^1.3.3",


### PR DESCRIPTION
Cloudflare Tunnels (CF Tunnels) buffered the response, it wasn't just Bun's fault but after testing some alternatives, LocalTunnel (`lt`) seems to work great with production-ready streamed responses.