### PR TITLE
use the correct binary for the localxpose CLI

### DIFF
--- a/scripts/tunnel.sh
+++ b/scripts/tunnel.sh
@@ -6,7 +6,7 @@ LOGFILE="tunnel.log"
 echo "Starting LocalXpose tunnel to localhost:$PORT (logging to $LOGFILE)..."
 
 while true; do
-  lx tunnel http --to localhost:$PORT >> "$LOGFILE" 2>&1
+  loclx tunnel http --to localhost:$PORT >> "$LOGFILE" 2>&1
   if [[ $? -ne 0 ]]; then
     echo "Tunnel crashed. Restarting in 5 seconds..."
     sleep 5


### PR DESCRIPTION
`lx` is not the correct binary for the LocalXpose CLI.

This PR corrects it by changing the script to use `loclx`, which is the correct binary for the LocalXpose CLI.

Install LocalXpose using
```
brew install --cask localxpose
```
> Command sourced from [here.](https://localxpose.io/download)