### PR TITLE
Port over Ollama runtime and models

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,11 @@ services:
       dockerfile: Dockerfile
     ports:
       - "2000:2000"
+    volumes:
+      - ~/.ollama/models:/root/.ollama/models
+      - ~/.ollama/runtime:/root/.ollama/runtime
     networks:
       - m3net
-
   ngrok-tunnel:
     build:
       context: .


### PR DESCRIPTION
This PR makes it where the Docker containers use the models and runtime already installed instead of installing the Ollama models and runtime inside of the Docker container.